### PR TITLE
lib.mkDebianPackages: add repository name argument

### DIFF
--- a/pkgs/debian-packages/default.nix
+++ b/pkgs/debian-packages/default.nix
@@ -4,6 +4,7 @@ let debianPackageVersion = "3.2-5";
     contrailVrouterUbuntu = kernel: lib.mkDebianPackage rec {
       name = "contrail-vrouter-module-${kernel.version}";
       version = debianPackageVersion;
+      repository = "contrail";
       contents = [ (contrailPkgs.lib.buildVrouter kernel) ];
       description = "Contrail vrouter kernel module for kernel ${kernel.version}";
       script = ''
@@ -28,6 +29,7 @@ in
   contrailVrouterUserland = lib.mkDebianPackage rec {
     name = "contrail-vrouter-userland";
     version = debianPackageVersion;
+    repository = "contrail";
     contents = [
       contrailPkgs.vrouterAgent contrailPkgs.vrouterPortControl
       contrailPkgs.vrouterUtils contrailPkgs.vrouterNetns ];


### PR DESCRIPTION
The repository is used to publish the Debian package to Aptly. It is
generally the name of the package (cloudwatt convention), but it could
be manually set in order to group several packages together.