### PR TITLE
dockerImages.contrailDiscovery: listen on all interfaces

### DIFF
--- a/pkgs/docker-images/config/contrail/default.nix
+++ b/pkgs/docker-images/config/contrail/default.nix
@@ -129,7 +129,7 @@ in rec {
     text = config {
       conf = {
         DEFAULTS = {
-          listen_ip_addr = containerIP;
+          listen_ip_addr = "0.0.0.0";
           listen_port = services.discovery.port;
           # minimim time to allow client to cache service information (seconds)
           ttl_min = 300;


### PR DESCRIPTION
We don't need to listen specifically on the container interface.

Moreover this change allows to use kubectl port-forward to get quick
access to the disco.